### PR TITLE
Convert to wakeup sources suspend blocker

### DIFF
--- a/drivers/char/diag_legacy/diagchar.h
+++ b/drivers/char/diag_legacy/diagchar.h
@@ -21,7 +21,6 @@
 #include <linux/spinlock.h>
 #include <linux/workqueue.h>
 #include <linux/sched.h>
-#include <linux/wakelock.h>
 #include <soc/qcom/smd.h>
 #include <asm/atomic.h>
 #include "diagfwd_bridge.h"

--- a/drivers/input/misc/adux1050.c
+++ b/drivers/input/misc/adux1050.c
@@ -46,7 +46,6 @@
 #include <linux/sched.h>
 #include <linux/slab.h>
 #include <linux/types.h>
-#include <linux/wakelock.h>
 #include <linux/wait.h>
 #include <linux/workqueue.h>
 #ifdef CONFIG_OF

--- a/drivers/usb/dwc3/dwc3-msm.c
+++ b/drivers/usb/dwc3/dwc3-msm.c
@@ -51,7 +51,6 @@
 #ifdef CONFIG_USB_DWC3_MSM_ID_POLL
 #include <linux/qpnp/qpnp-adc.h>
 #include <linux/fb.h>
-#include <linux/wakelock.h>
 #endif /* CONFIG_USB_DWC3_MSM_ID_POLL */
 
 #include "power.h"
@@ -301,7 +300,7 @@ struct dwc3_msm {
 	unsigned int		lcd_blanked;
 	struct wakeup_source	id_polling_wu;
 	struct delayed_work	setsink_work;
-	struct wake_lock	setsink_lock;
+	struct wakeup_source	setsink_lock;
 	int			setsink_cnt;
  #ifdef CONFIG_FB
 	struct notifier_block	fb_notif;
@@ -2859,8 +2858,7 @@ static void dwc3_setsink_work(struct work_struct *w)
 	int ret;
 
 	if (!mdwc->otg_present && mdwc->setsink_cnt < SETSINK_RETRY_MAX) {
-		wake_lock_timeout(&mdwc->setsink_lock,
-				msecs_to_jiffies(WAKELOCK_RETRY_INTERVAL));
+		__pm_wakeup_event(&mdwc->setsink_lock, WAKELOCK_RETRY_INTERVAL);
 		mdwc->setsink_cnt++;
 		power_supply_get_property(mdwc->usb_psy,
 				POWER_SUPPLY_PROP_TYPEC_POWER_ROLE, &val);
@@ -3039,8 +3037,7 @@ static int dwc3_msm_set_type_power_role(struct dwc3_msm *mdwc,
 
 	if (typec_power_role == POWER_SUPPLY_TYPEC_PR_SINK) {
 		mdwc->setsink_cnt = 0;
-		wake_lock_timeout(&mdwc->setsink_lock,
-				msecs_to_jiffies(WAKELOCK_RETRY_INTERVAL));
+		__pm_wakeup_event(&mdwc->setsink_lock, WAKELOCK_RETRY_INTERVAL);
 		schedule_delayed_work(&mdwc->setsink_work,
 				msecs_to_jiffies(SETSINK_RETRY_INTERVAL));
 	}
@@ -3751,7 +3748,7 @@ static int dwc3_msm_probe(struct platform_device *pdev)
 		mdwc->id_state = DWC3_ID_FLOAT;
 	}
 
-	wake_lock_init(&mdwc->setsink_lock, WAKE_LOCK_SUSPEND, "typecsink_lock");
+	wakeup_source_init(&mdwc->setsink_lock, "typecsink_lock");
 #endif /* CONFIG_USB_DWC3_MSM_ID_POLL */
 
 	res = platform_get_resource_byname(pdev, IORESOURCE_MEM, "tcsr_base");
@@ -4090,7 +4087,7 @@ uninit_iommu:
 	of_platform_depopulate(&pdev->dev);
 err:
 #ifdef CONFIG_USB_DWC3_MSM_ID_POLL
-	wake_lock_destroy(&mdwc->setsink_lock);
+	wakeup_source_trash(&mdwc->setsink_lock);
 #endif
 	destroy_workqueue(mdwc->dwc3_wq);
 	return ret;
@@ -4132,7 +4129,7 @@ static int dwc3_msm_remove(struct platform_device *pdev)
 	cancel_delayed_work_sync(&mdwc->perf_vote_work);
 #ifdef CONFIG_USB_DWC3_MSM_ID_POLL
 	cancel_delayed_work_sync(&mdwc->setsink_work);
-	wake_lock_destroy(&mdwc->setsink_lock);
+	wakeup_source_trash(&mdwc->setsink_lock);
 	if (mdwc->id_polling_use) {
 #ifdef CONFIG_FB
 		fb_unregister_client(&mdwc->fb_notif);


### PR DESCRIPTION
On kernel 4.9 the Android wakelocks are finally gone.
Convert the driver to use the wakeup sources in the Linux PM
API to achieve the very same goal and.

Remove unneeded header while there.