### PR TITLE
input: misc: vl53L0: Avoid compilation warning error

### DIFF
--- a/drivers/input/misc/vl53L0/src/vl53l0_api.c
+++ b/drivers/input/misc/vl53L0/src/vl53l0_api.c
@@ -2237,8 +2237,8 @@ VL53L0_Error VL53L0_CheckAndLoadInterruptSettings(VL53L0_DEV Dev,
 	uint8_t StartNotStopFlag)
 {
 	uint8_t InterruptConfig;
-	FixPoint1616_t ThresholdLow;
-	FixPoint1616_t ThresholdHigh;
+	FixPoint1616_t ThresholdLow = 0;
+	FixPoint1616_t ThresholdHigh = 0;
 	VL53L0_Error Status = VL53L0_ERROR_NONE;
 
 	InterruptConfig = VL53L0_GETDEVICESPECIFICPARAMETER(Dev,


### PR DESCRIPTION
drivers/input/misc/vl53L0/src/vl53l0_api.c:2258:35: warning: ThresholdHigh may be used uninitialized in this function [-Wmaybe-uninitialized]
error, forbidden warning: vl53l0_api.c:2258

I think the compiler is wrong but better intialize both values to shut it up.

Signed-off-by: Pablo Mendez Hernandez <pablomh@gmail.com>