### PR TITLE
kconfig: Avoid bad output format warning from GCC

### DIFF
--- a/scripts/kconfig/confdata.c
+++ b/scripts/kconfig/confdata.c
@@ -745,7 +745,7 @@ int conf_write(const char *name)
 	struct menu *menu;
 	const char *basename;
 	const char *str;
-	char dirname[PATH_MAX+1], tmpname[PATH_MAX+1], newname[PATH_MAX+1];
+	char dirname[PATH_MAX+1], tmpname[PATH_MAX+22], newname[PATH_MAX+8];
 	char *env;
 
 	dirname[0] = 0;

--- a/scripts/unifdef.c
+++ b/scripts/unifdef.c
@@ -450,7 +450,7 @@ static void Idrop (void) { Fdrop();  ignoreon(); }
 static void Itrue (void) { Ftrue();  ignoreon(); }
 static void Ifalse(void) { Ffalse(); ignoreon(); }
 /* modify this line */
-static void Mpass (void) { strncpy(keyword, "if  ", 4); Pelif(); }
+static void Mpass (void) { memcpy(keyword, "if  ", 4); Pelif(); }
 static void Mtrue (void) { keywordedit("else");  state(IS_TRUE_MIDDLE); }
 static void Melif (void) { keywordedit("endif"); state(IS_FALSE_TRAILER); }
 static void Melse (void) { keywordedit("endif"); state(IS_FALSE_ELSE); }


### PR DESCRIPTION
Make GCC happy.

kernel/sony/msm/scripts/unifdef.c: In function ‘Mpass’:
kernel/sony/msm/scripts/unifdef.c:453:28: warning: ‘strncpy’ output truncated
before terminating nul copying 4 bytes from a string of the same length
[-Wstringop-truncation]

 static void Mpass (void) { strncpy(keyword, "if  ", 4); Pelif(); }
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Humberto Borba <humberos@omnirom.org>
Change-Id: I1ac566a33ac4c5a0494da83c81fd9d553423eafc