### PR TITLE
[LA.UM.7.1.r1] msm ipa/gsi dbg: Fix preliminary argument size checks and print usage to user

### DIFF
--- a/drivers/platform/msm/gsi/gsi_dbg.c
+++ b/drivers/platform/msm/gsi/gsi_dbg.c
@@ -46,7 +46,7 @@ static ssize_t gsi_dump_evt(struct file *file,
 	uint16_t i;
 	int ret = 0;
 
-	if (count < 2)
+	if (count < 3)
 		return -EINVAL;
 
 	sptr = kmalloc((count+1) * sizeof(char), GFP_KERNEL);
@@ -175,7 +175,7 @@ static ssize_t gsi_dump_ch(struct file *file,
 	uint16_t i;
 	int ret = 0;
 
-	if (count < 2)
+	if (count < 3)
 		return -EINVAL;
 
 	sptr = kmalloc((count+1) * sizeof(char), GFP_KERNEL);
@@ -330,12 +330,12 @@ static ssize_t gsi_dump_stats(struct file *file,
 	int min, max;
 	char *sptr;
 
-	if (count < 2)
+	if (count < 1)
 		return -EINVAL;
 
 	sptr = kmalloc((count+1) * sizeof(char), GFP_KERNEL);
 	if (!sptr)
-		return -EINVAL;
+		return -ENOMEM;
 
 	if(copy_from_user(sptr, buf, count))
 		goto error;
@@ -459,7 +459,7 @@ static ssize_t gsi_set_max_elem_dp_stats(struct file *file,
 	unsigned long missing;
 	char *sptr, *token;
 
-	if (count < 2)
+	if (count < 1)
 		return -EINVAL;
 
 	sptr = kmalloc((count+1) * sizeof(char), GFP_KERNEL);
@@ -586,7 +586,7 @@ static ssize_t gsi_rst_stats(struct file *file,
 	int min, max;
 	char *sptr;
 
-	if (count < 2)
+	if (count < 1)
 		return -EINVAL;
 
 	sptr = kmalloc((count+1) * sizeof(char), GFP_KERNEL);
@@ -694,12 +694,12 @@ static ssize_t gsi_enable_ipc_low(struct file *file,
 	char *sptr;
 	int ret = 0;
 
-	if (count < 2)
+	if (count < 1)
 		return ret;
 
 	sptr = kmalloc((count+1) * sizeof(char), GFP_KERNEL);
 	if (!sptr)
-		return ret;
+		return -ENOMEM;
 
 	missing = copy_from_user(sptr, ubuf, count);
 	if (missing) {

--- a/drivers/platform/msm/gsi/gsi_dbg.c
+++ b/drivers/platform/msm/gsi/gsi_dbg.c
@@ -331,7 +331,7 @@ static ssize_t gsi_dump_stats(struct file *file,
 	char *sptr;
 
 	if (count < 1)
-		return -EINVAL;
+		goto print_help;
 
 	sptr = kmalloc((count+1) * sizeof(char), GFP_KERNEL);
 	if (!sptr)
@@ -361,6 +361,7 @@ static ssize_t gsi_dump_stats(struct file *file,
 	return count;
 error:
 	kfree(sptr);
+print_help:
 	TERR("Usage: echo ch_id > stats. Use -1 for all\n");
 	return -EINVAL;
 }
@@ -395,7 +396,7 @@ static ssize_t gsi_enable_dp_stats(struct file *file,
 	char *sptr;
 
 	if (count < 2)
-		return -EINVAL;
+		goto print_help;
 
 	sptr = kmalloc((count+1) * sizeof(char), GFP_KERNEL);
 	if (!sptr)
@@ -447,6 +448,7 @@ static ssize_t gsi_enable_dp_stats(struct file *file,
 	return count;
 error:
 	kfree(sptr);
+print_help:
 	TERR("Usage: echo [+-]ch_id > enable_dp_stats\n");
 	return -EINVAL;
 }
@@ -460,7 +462,7 @@ static ssize_t gsi_set_max_elem_dp_stats(struct file *file,
 	char *sptr, *token;
 
 	if (count < 1)
-		return -EINVAL;
+		goto print_help;
 
 	sptr = kmalloc((count+1) * sizeof(char), GFP_KERNEL);
 	if (!sptr)
@@ -513,6 +515,7 @@ end:
 
 error:
 	kfree(sptr);
+print_help:
 	TERR("Usage: (set) echo <ch_id> <max_elem> > max_elem_dp_stats\n");
 	TERR("Usage: (get) echo <ch_id> > max_elem_dp_stats\n");
 	return -EINVAL;
@@ -587,7 +590,7 @@ static ssize_t gsi_rst_stats(struct file *file,
 	char *sptr;
 
 	if (count < 1)
-		return -EINVAL;
+		goto print_help;
 
 	sptr = kmalloc((count+1) * sizeof(char), GFP_KERNEL);
 	if (!sptr)
@@ -618,6 +621,7 @@ static ssize_t gsi_rst_stats(struct file *file,
 	return count;
 error:
 	kfree(sptr);
+print_help:
 	TERR("Usage: echo ch_id > rst_stats. Use -1 for all\n");
 	return -EINVAL;
 }
@@ -631,7 +635,7 @@ static ssize_t gsi_print_dp_stats(struct file *file,
 	char *sptr;
 
 	if (count < 2)
-		return -EINVAL;
+		goto print_help;
 
 	sptr = kmalloc((count+1) * sizeof(char), GFP_KERNEL);
 	if (!sptr)
@@ -682,6 +686,7 @@ static ssize_t gsi_print_dp_stats(struct file *file,
 	return count;
 error:
 	kfree(sptr);
+print_help:
 	TERR("Usage: echo [+-]ch_id > print_dp_stats\n");
 	return -EINVAL;
 }
@@ -695,7 +700,7 @@ static ssize_t gsi_enable_ipc_low(struct file *file,
 	int ret = 0;
 
 	if (count < 1)
-		return ret;
+		return -EINVAL;
 
 	sptr = kmalloc((count+1) * sizeof(char), GFP_KERNEL);
 	if (!sptr)

--- a/drivers/platform/msm/ipa/ipa_v3/ipa.c
+++ b/drivers/platform/msm/ipa/ipa_v3/ipa.c
@@ -5121,8 +5121,8 @@ static ssize_t ipa3_write(struct file *file, const char __user *buf,
 	char *dbg_buff = NULL;
 	int ret = 0;
 
-	if (count < 2)
-		return -EFAULT;
+	if (count < 1)
+		return -EINVAL;
 
 	dbg_buff = kmalloc((count + 1) * sizeof(char), GFP_KERNEL);
 	if (!dbg_buff)
@@ -5180,7 +5180,7 @@ static ssize_t ipa3_write(struct file *file, const char __user *buf,
 		} else if (strcmp(dbg_buff, "1")) {
 			IPAERR("got invalid string %s not loading FW\n",
 				dbg_buff);
-			goto end_msg;
+			goto end;
 		}
 		pr_info("IPA is loading with %sMHI configuration\n",
 			ipa3_ctx->ipa_config_is_mhi ? "" : "non ");


### PR DESCRIPTION
Some debug functions take smaller or larger minimum strings: fix the `if`s to account for these. Also, print the error messages to the user when their argument is invalid, just like when it's incorrect for another reason.
Finally, fix some of the returns to return the right error code on wrong user input (`EINVAL` instead of `0` or `EFAULT`).