### PR TITLE
[LA.UM.7.1.r1] Fix lpm levels for SDM630/MSM899{6,8}

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8956-pm.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956-pm.dtsi
@@ -90,7 +90,9 @@
 				reg = <2>;
 				label = "system-cci-pc";
 				qcom,psci-mode = <2>;
-				qcom,entry-latency-us = <9582>;
+				/* TODO: WARNING: time_overhead - last_exit_latency <= 0
+				 * Using safe value time_overhead; please recalculate */
+				qcom,entry-latency-us = <1158>;
 				qcom,exit-latency-us = <10740>;
 				qcom,min-residency-us = <7800>;
 				qcom,min-child-idx = <3>;

--- a/arch/arm64/boot/dts/qcom/msm8996-pm.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8996-pm.dtsi
@@ -69,7 +69,7 @@
 				qcom,reset-level = <LPM_RESET_LVL_RET>;
 			};
 			qcom,pm-cluster-level@2{ /* E4-M3 */
-				reg = <1>;
+				reg = <2>;
 				label = "system-fpc";
 				qcom,spm-cbf-mode = "fpc";
 				qcom,spm-l3-mode = "fpc";

--- a/arch/arm64/boot/dts/qcom/sdm630-pm.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm630-pm.dtsi
@@ -153,7 +153,7 @@
 						qcom,spm-cpu-mode = "ret";
 						qcom,entry-latency-us = <163>;
 						qcom,exit-latency-us = <90>;
-						qcom,min-residency-us = <984>;
+						qcom,min-residency-us = <610>;
 					};
 
 					qcom,pm-cpu-level@2 {  /* C3 */
@@ -163,7 +163,7 @@
 						qcom,psci-cpu-mode = <0x3>;
 						qcom,entry-latency-us = <262>;
 						qcom,exit-latency-us = <343>;
-						qcom,min-residency-us = <1092>;
+						qcom,min-residency-us = <1849>;
 						qcom,is-reset;
 						qcom,use-broadcast-timer;
 					};
@@ -186,7 +186,7 @@
 					qcom,psci-mode = <0x1>;
 					qcom,entry-latency-us = <38>;
 					qcom,exit-latency-us = <51>;
-					qcom,min-residency-us = <91>;
+					qcom,min-residency-us = <89>;
 				};
 
 				qcom,pm-cluster-level@1{ /* D2D */
@@ -195,7 +195,7 @@
 					qcom,psci-mode = <2>;
 					qcom,entry-latency-us = <272>;
 					qcom,exit-latency-us = <329>;
-					qcom,min-residency-us = <984>;
+					qcom,min-residency-us = <602>;
 					qcom,min-child-idx = <1>;
 				};
 
@@ -205,7 +205,7 @@
 					qcom,psci-mode = <3>;
 					qcom,entry-latency-us = <332>;
 					qcom,exit-latency-us = <368>;
-					qcom,min-residency-us = <1092>;
+					qcom,min-residency-us = <1463>;
 					qcom,min-child-idx = <2>;
 				};
 
@@ -215,7 +215,7 @@
 					qcom,psci-mode = <0x4>;
 					qcom,entry-latency-us = <545>;
 					qcom,exit-latency-us = <1609>;
-					qcom,min-residency-us = <6426>;
+					qcom,min-residency-us = <6145>;
 					qcom,min-child-idx = <2>;
 					qcom,is-reset;
 				};
@@ -234,7 +234,7 @@
 						qcom,psci-cpu-mode = <0x1>;
 						qcom,entry-latency-us = <44>;
 						qcom,exit-latency-us = <39>;
-						qcom,min-residency-us = <91>;
+						qcom,min-residency-us = <83>;
 					};
 
 					qcom,pm-cpu-level@1 { /* C2D */
@@ -244,7 +244,7 @@
 						qcom,spm-cpu-mode = "ret";
 						qcom,entry-latency-us = <154>;
 						qcom,exit-latency-us = <87>;
-						qcom,min-residency-us = <984>;
+						qcom,min-residency-us = <498>;
 					};
 
 					qcom,pm-cpu-level@2 { /* C3 */
@@ -254,7 +254,7 @@
 						qcom,psci-cpu-mode = <0x3>;
 						qcom,entry-latency-us = <262>;
 						qcom,exit-latency-us = <301>;
-						qcom,min-residency-us = <1092>;
+						qcom,min-residency-us = <2022>;
 						qcom,is-reset;
 						qcom,use-broadcast-timer;
 					};


### PR DESCRIPTION
The CPU residencies were wrong on SDM630. The cluster ID for MSM8996 was wrong but apparently the corrected levels were already picked.

Also, add a warning for negative `entry-latency` (when calculated from `time-overhead - exit-latency`), and use `time-overhead` instead of `abs(time-overhead - exit-latency)`.